### PR TITLE
Allow pinging while dead

### DIFF
--- a/lua/autorun/client/cl_contextual_ping.lua
+++ b/lua/autorun/client/cl_contextual_ping.lua
@@ -39,8 +39,6 @@ function PingLocation(isTeam)
     local pingLoc = eye.HitPos
     local pingEnt = eye.Entity
 
-    if !ply:Alive() then return end
-
     if isTTT then
         if ply:IsSpec() then return end
     end


### PR DESCRIPTION
This seems to only be useful for the intended gamemode (TTT) as to not let people ghost but it works fine with horde as is with this line removed; allowing people to ping potential threats while dead.